### PR TITLE
Adding v1.5 stuff and using LooseVersion

### DIFF
--- a/docs/vyos.vyos.vyos_firewall_rules_module.rst
+++ b/docs/vyos.vyos.vyos_firewall_rules_module.rst
@@ -546,10 +546,10 @@ Parameters
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    VyOS 1.4 & older:<br>
+                                <br><i>VyOS 1.4 & older:</i><br>
                                     <li>match-ipsec</li>
                                     <li>match-none</li>
-                                    VyOS 1.5+ :<br>
+                                <br><i>VyOS 1.5+ :</i><br>
                                     <li>match-ipsec-in</li>
                                     <li>match-ipsec-out</li>
                                     <li>match-none-in</li>

--- a/docs/vyos.vyos.vyos_firewall_rules_module.rst
+++ b/docs/vyos.vyos.vyos_firewall_rules_module.rst
@@ -546,8 +546,14 @@ Parameters
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    VyOS 1.4 & older:<br>
                                     <li>match-ipsec</li>
                                     <li>match-none</li>
+                                    VyOS 1.5+ :<br>
+                                    <li>match-ipsec-in</li>
+                                    <li>match-ipsec-out</li>
+                                    <li>match-none-in</li>
+                                    <li>match-none-out</li>
                         </ul>
                 </td>
                 <td>

--- a/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
@@ -169,7 +169,7 @@ class Firewall_rulesArgs(object):  # pylint: disable=R0903
                                     "type": "dict",
                                 },
                                 "ipsec": {
-                                    "choices": ["match-ipsec", "match-none", "match-ipsec-in", "match-ipsec-out", "match-none-in", "match-ipsec-out"],
+                                    "choices": ["match-ipsec", "match-none", "match-ipsec-in", "match-ipsec-out", "match-none-in", "match-none-out"],
                                     "type": "str"
                                 },
                                 "jump_target": {

--- a/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
@@ -169,7 +169,7 @@ class Firewall_rulesArgs(object):  # pylint: disable=R0903
                                     "type": "dict",
                                 },
                                 "ipsec": {
-                                    "choices": ["match-ipsec", "match-none"],
+                                    "choices": ["match-ipsec", "match-none", 'match-ipsec-in', 'match-ipsec-out', 'match-none-in', 'match-ipsec-out'],
                                     "type": "str"
                                 },
                                 "jump_target": {

--- a/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/argspec/firewall_rules/firewall_rules.py
@@ -169,7 +169,7 @@ class Firewall_rulesArgs(object):  # pylint: disable=R0903
                                     "type": "dict",
                                 },
                                 "ipsec": {
-                                    "choices": ["match-ipsec", "match-none", 'match-ipsec-in', 'match-ipsec-out', 'match-none-in', 'match-ipsec-out'],
+                                    "choices": ["match-ipsec", "match-none", "match-ipsec-in", "match-ipsec-out", "match-none-in", "match-ipsec-out"],
                                     "type": "str"
                                 },
                                 "jump_target": {

--- a/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
@@ -46,9 +46,9 @@ class Firewall_global(ConfigBase):
     gather_network_resources = ["firewall_global"]
 
     def __init__(self, module):
-        global os_version
+        # global os_version
         super(Firewall_global, self).__init__(module)
-        os_version =  get_os_version(self._module)
+        # os_version =  get_os_version(self._module)
 
     def get_firewall_global_facts(self, data=None):
         """Get the 'facts' (the current configuration)
@@ -646,7 +646,7 @@ class Firewall_global(ConfigBase):
             cmd = "delete firewall "
         else:
             cmd = "set firewall "
-        if key != "group" and LooseVersion(os_version) >= LooseVersion("1.4"):
+        if key != "group" and LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             cmd += "global-options "
         if key:
             cmd += key.replace("_", "-") + " "

--- a/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
@@ -646,7 +646,7 @@ class Firewall_global(ConfigBase):
             cmd = "delete firewall "
         else:
             cmd = "set firewall "
-        if key != "group" and LooseVersion(os_version) >= LooseVersion('1.4'):
+        if key != "group" and LooseVersion(os_version) >= LooseVersion("1.4"):
             cmd += "global-options "
         if key:
             cmd += key.replace("_", "-") + " "

--- a/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
+++ b/plugins/module_utils/network/vyos/config/firewall_global/firewall_global.py
@@ -31,6 +31,10 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.utils
     list_diff_want_only,
 )
 
+from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import get_os_version
+
+from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.version import LooseVersion
+
 
 class Firewall_global(ConfigBase):
     """
@@ -42,7 +46,9 @@ class Firewall_global(ConfigBase):
     gather_network_resources = ["firewall_global"]
 
     def __init__(self, module):
+        global os_version
         super(Firewall_global, self).__init__(module)
+        os_version =  get_os_version(self._module)
 
     def get_firewall_global_facts(self, data=None):
         """Get the 'facts' (the current configuration)
@@ -640,7 +646,7 @@ class Firewall_global(ConfigBase):
             cmd = "delete firewall "
         else:
             cmd = "set firewall "
-        if key != "group" and self._get_os_version() >= '1.4':
+        if key != "group" and LooseVersion(os_version) >= LooseVersion('1.4'):
             cmd += "global-options "
         if key:
             cmd += key.replace("_", "-") + " "
@@ -751,12 +757,3 @@ class Firewall_global(ConfigBase):
         elif attrib == "validation":
             regex = "source-validation"
         return regex
-
-    def _get_os_version(self):
-        """
-        Get the base version number before the '-' in the version string.
-        """
-        os_version = "1.2"
-        if self._connection:
-            os_version = self._connection.get_device_info()["network_os_major_version"]
-        return os_version

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -51,9 +51,9 @@ class Firewall_rules(ConfigBase):
     ]
 
     def __init__(self, module):
-        global os_version
+        # global os_version
         super(Firewall_rules, self).__init__(module)
-        os_version =  get_os_version(self._module)
+        # os_version =  get_os_version(self._module)
 
     def get_firewall_rules_facts(self, data=None):
         """Get the 'facts' (the current configuration)
@@ -497,7 +497,7 @@ class Firewall_rules(ConfigBase):
                     and not (h_icmp and self._is_w_same(w[attr], h_icmp, item))
                 ):
                     if item == "type_name":
-                        if LooseVersion(os_version) >= LooseVersion("1.4"):
+                        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
                             param_name = "type-name"
                         else:
                             param_name = "type"
@@ -682,7 +682,7 @@ class Firewall_rules(ConfigBase):
         :param cmd: commands to be prepend.
         :return: generated list of commands.
         """
-        if LooseVersion(os_version) >= LooseVersion("1.4"):
+        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             return self._add_tcp_1_4(attr, w, h, cmd, opr)
         h_tcp = {}
         commands = []
@@ -916,7 +916,7 @@ class Firewall_rules(ConfigBase):
             cmd = "delete firewall " + self._get_fw_type(rs_id["afi"])
         else:
             cmd = "set firewall " + self._get_fw_type(rs_id["afi"])
-        if LooseVersion(os_version) >= LooseVersion("1.4"):
+        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             if rs_id["name"]:
                 cmd += " name " + rs_id["name"]
             elif rs_id["filter"]:
@@ -926,7 +926,7 @@ class Firewall_rules(ConfigBase):
         if number:
             cmd += " rule " + str(number)
         if attrib:
-            if LooseVersion(os_version) >= LooseVersion("1.4")  and attrib == "enable_default_log": 
+            if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4")  and attrib == "enable_default_log": 
                 cmd += " " + "default-log"
             else:
                 cmd += " " + attrib.replace("_", "-")
@@ -1024,7 +1024,7 @@ class Firewall_rules(ConfigBase):
         :param afi: address type
         :return: rule-set type.
         """
-        if LooseVersion(os_version) >= LooseVersion("1.4"):
+        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             return "ipv6" if afi == "ipv6" else "ipv4"
         return "ipv6-name" if afi == "ipv6" else "name"
 

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -497,7 +497,7 @@ class Firewall_rules(ConfigBase):
                     and not (h_icmp and self._is_w_same(w[attr], h_icmp, item))
                 ):
                     if item == "type_name":
-                        if LooseVersion(os_version) >= LooseVersion('1.4'):
+                        if LooseVersion(os_version) >= LooseVersion("1.4"):
                             param_name = "type-name"
                         else:
                             param_name = "type"
@@ -682,7 +682,7 @@ class Firewall_rules(ConfigBase):
         :param cmd: commands to be prepend.
         :return: generated list of commands.
         """
-        if LooseVersion(os_version) >= LooseVersion('1.4'):
+        if LooseVersion(os_version) >= LooseVersion("1.4"):
             return self._add_tcp_1_4(attr, w, h, cmd, opr)
         h_tcp = {}
         commands = []
@@ -916,7 +916,7 @@ class Firewall_rules(ConfigBase):
             cmd = "delete firewall " + self._get_fw_type(rs_id["afi"])
         else:
             cmd = "set firewall " + self._get_fw_type(rs_id["afi"])
-        if LooseVersion(os_version) >= LooseVersion('1.4'):
+        if LooseVersion(os_version) >= LooseVersion("1.4"):
             if rs_id["name"]:
                 cmd += " name " + rs_id["name"]
             elif rs_id["filter"]:
@@ -926,7 +926,7 @@ class Firewall_rules(ConfigBase):
         if number:
             cmd += " rule " + str(number)
         if attrib:
-            if LooseVersion(os_version) >= LooseVersion('1.4')  and attrib == "enable_default_log": 
+            if LooseVersion(os_version) >= LooseVersion("1.4")  and attrib == "enable_default_log": 
                 cmd += " " + "default-log"
             else:
                 cmd += " " + attrib.replace("_", "-")
@@ -1024,7 +1024,7 @@ class Firewall_rules(ConfigBase):
         :param afi: address type
         :return: rule-set type.
         """
-        if LooseVersion(os_version) >= LooseVersion('1.4'):
+        if LooseVersion(os_version) >= LooseVersion("1.4"):
             return "ipv6" if afi == "ipv6" else "ipv4"
         return "ipv6-name" if afi == "ipv6" else "name"
 

--- a/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
+++ b/plugins/module_utils/network/vyos/config/firewall_rules/firewall_rules.py
@@ -926,7 +926,7 @@ class Firewall_rules(ConfigBase):
         if number:
             cmd += " rule " + str(number)
         if attrib:
-            if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4")  and attrib == "enable_default_log": 
+            if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4") and attrib == "enable_default_log":
                 cmd += " " + "default-log"
             else:
                 cmd += " " + attrib.replace("_", "-")

--- a/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
@@ -79,7 +79,7 @@ class Ospf_interfaces(ResourceModule):
         else:
             version = self._module.params.get("version")
         # if version >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion('1.4'):
+        if LooseVersion(os_version) >= LooseVersion("1.4"):
             self._tmplt = Ospf_interfacesTemplate14()
         else:
             self._tmplt = Ospf_interfacesTemplate()

--- a/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
@@ -34,6 +34,9 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.rm_template
     Ospf_interfacesTemplate14
 )
 
+from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import get_os_version
+
+from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.version import LooseVersion
 
 class Ospf_interfaces(ResourceModule):
     """
@@ -41,6 +44,7 @@ class Ospf_interfaces(ResourceModule):
     """
 
     def __init__(self, module):
+        global os_version
         super(Ospf_interfaces, self).__init__(
             empty_fact_val={},
             facts_module=Facts(module),
@@ -64,6 +68,7 @@ class Ospf_interfaces(ResourceModule):
             "instance",
             "passive",
         ]
+        os_version =  get_os_version(self._module)
 
     def _validate_template(self):
         if self._module.params.get("version") == "detect":
@@ -73,7 +78,8 @@ class Ospf_interfaces(ResourceModule):
                 version = "1.2"  # default to 1.2 if no connection
         else:
             version = self._module.params.get("version")
-        if version >= "1.4":
+        # if version >= "1.4":
+        if LooseVersion(os_version) >= LooseVersion('1.4'):
             self._tmplt = Ospf_interfacesTemplate14()
         else:
             self._tmplt = Ospf_interfacesTemplate()

--- a/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
@@ -38,6 +38,7 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import
 
 from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.version import LooseVersion
 
+
 class Ospf_interfaces(ResourceModule):
     """
     The vyos_ospf_interfaces config class

--- a/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/vyos/config/ospf_interfaces/ospf_interfaces.py
@@ -44,7 +44,7 @@ class Ospf_interfaces(ResourceModule):
     """
 
     def __init__(self, module):
-        global os_version
+        # global os_version
         super(Ospf_interfaces, self).__init__(
             empty_fact_val={},
             facts_module=Facts(module),
@@ -68,7 +68,7 @@ class Ospf_interfaces(ResourceModule):
             "instance",
             "passive",
         ]
-        os_version =  get_os_version(self._module)
+        # os_version =  get_os_version(self._module)
 
     def _validate_template(self):
         if self._module.params.get("version") == "detect":
@@ -79,7 +79,7 @@ class Ospf_interfaces(ResourceModule):
         else:
             version = self._module.params.get("version")
         # if version >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion("1.4"):
+        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             self._tmplt = Ospf_interfacesTemplate14()
         else:
             self._tmplt = Ospf_interfacesTemplate()

--- a/plugins/module_utils/network/vyos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/ospf_interfaces/ospf_interfaces.py
@@ -30,16 +30,23 @@ from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.rm_template
     Ospf_interfacesTemplate14
 )
 
+from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.vyos import get_os_version
+
+from ansible_collections.vyos.vyos.plugins.module_utils.network.vyos.utils.version import LooseVersion
+
 
 class Ospf_interfacesFacts(object):
     """The vyos ospf_interfaces facts class"""
 
     def __init__(self, module, subspec="config", options="options"):
+        global os_version
         self._module = module
         self.argument_spec = Ospf_interfacesArgs.argument_spec
+        os_version =  get_os_version(self._module)
 
     def get_device_data(self, connection):
-        if self._get_os_version(connection) >= "1.4":
+        # if self._get_os_version(connection) >= "1.4":
+        if LooseVersion(os_version) >= LooseVersion('1.4'):
             # use set protocols ospf in order to get both ospf and ospfv3
             return connection.get("show configuration commands |  match 'set protocols ospf'")
         return connection.get('show configuration commands |  match "set interfaces"')
@@ -82,7 +89,8 @@ class Ospf_interfacesFacts(object):
 
     def get_config_set(self, data, connection):
         """To classify the configurations beased on interface"""
-        if self._get_os_version(connection) >= "1.4":
+        # if self._get_os_version(connection) >= "1.4":
+        if LooseVersion(os_version) >= LooseVersion('1.4'):
             return self.get_config_set_1_4(data)
         return self.get_config_set_1_2(data)
 
@@ -98,7 +106,8 @@ class Ospf_interfacesFacts(object):
         """
         facts = {}
         objs = []
-        if self._get_os_version(connection) >= "1.4":
+        # if self._get_os_version(connection) >= "1.4":
+        if LooseVersion(os_version) >= LooseVersion('1.4'):
             ospf_interface_class = Ospf_interfacesTemplate14
         else:
             ospf_interface_class = Ospf_interfacesTemplate
@@ -137,11 +146,11 @@ class Ospf_interfacesFacts(object):
 
         return ansible_facts
 
-    def _get_os_version(self, connection):
-        """
-        Get the base version number before the '-' in the version string.
-        """
-        os_version = "1.2"
-        if connection:
-            os_version = connection.get_device_info()["network_os_major_version"]
-        return os_version
+    # def _get_os_version(self, connection):
+    #     """
+    #     Get the base version number before the '-' in the version string.
+    #     """
+    #     os_version = "1.2"
+    #     if connection:
+    #         os_version = connection.get_device_info()["network_os_major_version"]
+    #     return os_version

--- a/plugins/module_utils/network/vyos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/ospf_interfaces/ospf_interfaces.py
@@ -46,7 +46,7 @@ class Ospf_interfacesFacts(object):
 
     def get_device_data(self, connection):
         # if self._get_os_version(connection) >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion('1.4'):
+        if LooseVersion(os_version) >= LooseVersion("1.4"):
             # use set protocols ospf in order to get both ospf and ospfv3
             return connection.get("show configuration commands |  match 'set protocols ospf'")
         return connection.get('show configuration commands |  match "set interfaces"')
@@ -90,7 +90,7 @@ class Ospf_interfacesFacts(object):
     def get_config_set(self, data, connection):
         """To classify the configurations beased on interface"""
         # if self._get_os_version(connection) >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion('1.4'):
+        if LooseVersion(os_version) >= LooseVersion("1.4"):
             return self.get_config_set_1_4(data)
         return self.get_config_set_1_2(data)
 
@@ -107,7 +107,7 @@ class Ospf_interfacesFacts(object):
         facts = {}
         objs = []
         # if self._get_os_version(connection) >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion('1.4'):
+        if LooseVersion(os_version) >= LooseVersion("1.4"):
             ospf_interface_class = Ospf_interfacesTemplate14
         else:
             ospf_interface_class = Ospf_interfacesTemplate

--- a/plugins/module_utils/network/vyos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/vyos/facts/ospf_interfaces/ospf_interfaces.py
@@ -39,14 +39,14 @@ class Ospf_interfacesFacts(object):
     """The vyos ospf_interfaces facts class"""
 
     def __init__(self, module, subspec="config", options="options"):
-        global os_version
+        # global os_version
         self._module = module
         self.argument_spec = Ospf_interfacesArgs.argument_spec
-        os_version =  get_os_version(self._module)
+        # os_version =  get_os_version(self._module)
 
     def get_device_data(self, connection):
         # if self._get_os_version(connection) >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion("1.4"):
+        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             # use set protocols ospf in order to get both ospf and ospfv3
             return connection.get("show configuration commands |  match 'set protocols ospf'")
         return connection.get('show configuration commands |  match "set interfaces"')
@@ -90,7 +90,7 @@ class Ospf_interfacesFacts(object):
     def get_config_set(self, data, connection):
         """To classify the configurations beased on interface"""
         # if self._get_os_version(connection) >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion("1.4"):
+        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             return self.get_config_set_1_4(data)
         return self.get_config_set_1_2(data)
 
@@ -107,7 +107,7 @@ class Ospf_interfacesFacts(object):
         facts = {}
         objs = []
         # if self._get_os_version(connection) >= "1.4":
-        if LooseVersion(os_version) >= LooseVersion("1.4"):
+        if LooseVersion(get_os_version(self._module)) >= LooseVersion("1.4"):
             ospf_interface_class = Ospf_interfacesTemplate14
         else:
             ospf_interface_class = Ospf_interfacesTemplate

--- a/plugins/module_utils/network/vyos/utils/version.py
+++ b/plugins/module_utils/network/vyos/utils/version.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Provide version object to compare version numbers."""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+from ansible.module_utils.compat.version import LooseVersion 

--- a/plugins/module_utils/network/vyos/utils/version.py
+++ b/plugins/module_utils/network/vyos/utils/version.py
@@ -10,4 +10,4 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-from ansible.module_utils.compat.version import LooseVersion 
+from ansible.module_utils.compat.version import LooseVersion

--- a/plugins/module_utils/network/vyos/vyos.py
+++ b/plugins/module_utils/network/vyos/vyos.py
@@ -34,7 +34,6 @@ import json
 from ansible.module_utils._text import to_text
 from ansible.module_utils.connection import Connection, ConnectionError
 
-
 _DEVICE_CONFIGS = {}
 
 
@@ -100,3 +99,9 @@ def load_config(module, commands, commit=False, comment=None):
         module.fail_json(msg=to_text(exc, errors="surrogate_then_replace"))
 
     return response.get("diff")
+
+def get_os_version(module):
+    connection = get_connection(module)
+    if connection.get_device_info():
+        os_version = connection.get_device_info()["network_os_major_version"]
+    return os_version

--- a/plugins/module_utils/network/vyos/vyos.py
+++ b/plugins/module_utils/network/vyos/vyos.py
@@ -100,6 +100,7 @@ def load_config(module, commands, commit=False, comment=None):
 
     return response.get("diff")
 
+
 def get_os_version(module):
     connection = get_connection(module)
     if connection.get_device_info():

--- a/plugins/modules/vyos_firewall_rules.py
+++ b/plugins/modules/vyos_firewall_rules.py
@@ -261,6 +261,10 @@ options:
                 choices:
                 - match-ipsec
                 - match-none
+                - match-ipsec-in
+                - match-ipsec-out
+                - match-none-in
+                - match-none-out
               jump_target:
                 description:
                   - Jump target if the action is jump.


### PR DESCRIPTION
I changed the parts I found suboptimal while reviewing https://github.com/vyos/vyos.vyos/pull/352, namely:
+ moved device interrogation for device_info (get_os_version) to single place
+ Introduced built-in ansible LooseVersion function to test version numbers more reliably
+ Added support of match-*-in/out to argspecs for v1.5. firewall rules
+ Changes version checks where practical
+ Tested against v1.3. and v1.4. and 1.5 lab devices

Outstanding:
+ rst docomentation for  new match-*-in/out variants
+ tests were not updated as yet