### PR TITLE
suppressing sanity checks for unused-import

### DIFF
--- a/plugins/module_utils/network/vyos/utils/version.py
+++ b/plugins/module_utils/network/vyos/utils/version.py
@@ -10,4 +10,4 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-from ansible.module_utils.compat.version import LooseVersion
+from ansible.module_utils.compat.version import LooseVersion  # pylint: disable=unused-import


### PR DESCRIPTION
The change suppresses pylint error 'unused-import' 